### PR TITLE
getting rid of external names saves time

### DIFF
--- a/MyPlayground.playground/Pages/main.xcplaygroundpage/Contents.swift
+++ b/MyPlayground.playground/Pages/main.xcplaygroundpage/Contents.swift
@@ -13,10 +13,11 @@
 /*: question1
  ### 1. Create a function that will take in a continent and the number of countries in that continent. It should print the following sentence "____ is a continent which contains ___ countries".
  */
-// write your code here
+func continentCountries (_ cont: String, _ countries: Int){
+    print ("\(cont) is a continent which contains \(countries) countries")
+}
 
-
-
+continentCountries ("Africa" , 54)
 
 /*: question2
  ### 2. Can you see why the code below doesn't work? Fix the function call to get rid of the error.
@@ -25,28 +26,31 @@ func greeting(name: String, greeting: String) {
     print("\(greeting), \(name)!")
 }
 
-greeting(name: "Danny", "Hello")
+greeting(name: "Danny", greeting: "Hello")
 
-
+//by default, parameters must be labeled with external names. this can be overrided with "_" where functions are declared (see above)
 
 
 /*: question3
  ### 3. This function doesn't work, either. Can you fix the function (_not_ the call) so that it works?
  */
-func daysInMonth(month: String, days: String) {
-    print("There are \(days) in \(month)")
+func daysInMonth(month: String, days: Int) {
+    print("There are \(days) days in \(month)")
 }
 
 daysInMonth(month: "November", days: 30)
-
+//function declaration asked for String, changed type to Int
 
 
 
 /*: question4
  ### 4. So far, you have created functions that take two arguments. Can you create (and call) one that takes three? Try to create a function that three parameters: a beverage, the number of bottles of that beverage, and a place you can keep those bottles. Print the sentence "____ bottles of ____ on the ____ wall."
  */
-// write your code here
+func bevmoInventory(_ bevNum: Int, _ bevType: String, _ bevLocation: String){
+    print ("\(bevNum) botles of \(bevType) on the \(bevLocation).")
+}
 
+bevmoInventory(99, "beer" , "wall")
 
 
 


### PR DESCRIPTION
- I thought that getting rid of Wall from inside the quotes went better with the spirit of the assignment.

- I'm wondering if there is any reason why you would want to use external names, seems to save a bit of typing without them. Maybe just for documentation purposes (admittedly a fairly strong reason)